### PR TITLE
Twitch adapter now sends raw CAP REQs for twitch.tv/command

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,4 @@ The adapter also supports the following environmental variables:
 - ```HUBOT_TWITCH_REDIRECT_URI```
 - ```HUBOT_TWITCH_OWNERS```
 - ```HUBOT_TWITCH_DEBUG```
+- ```HUBOT_TWITCH_DELAY```

--- a/src/twitch.coffee
+++ b/src/twitch.coffee
@@ -28,6 +28,7 @@ class Twitch extends Adapter
       owners: process.env.HUBOT_TWITCH_OWNERS?.split "," || []
       channels: process.env.HUBOT_TWITCH_CHANNELS?.split "," || []
       debug: process.env.HUBOT_TWITCH_DEBUG || false
+      delay: process.env.HUBOT_TWITCH_DELAY || 1100
 
     @robot.name = @options.nick
 
@@ -57,6 +58,10 @@ class Twitch extends Adapter
       debug: @options.debug
       port: @options.port
 
+    if parseInt(@options.delay) isnt 0
+      clientOptions["floodProtection"] = true
+      clientOptions["floodProtectionDelay"] = parseInt(@options.delay)
+
     # see: http://node-irc.readthedocs.org/en/latest/API.html#client
     client = new irc.Client @options.server, @options.nick, clientOptions
 
@@ -69,7 +74,10 @@ class Twitch extends Adapter
     client.addListener "notice", @onNotice
     client.addListener "part", @onPart
     client.addListener "quit", @onQuit
+
+    client.send("raw CAP REQ :twitch.tv/commands")
     client.send("raw CAP REQ :twitch.tv/membership")
+#    client.send("raw CAP REQ :twitch.tv/tags")
 
     @ircClient = client
 


### PR DESCRIPTION
Twitch adapter now also checks for flood protection environment variable and sets it via irc client flood protection boolean and flood protection delay.
Flood protection defaults to on at 1100ms since twitch is a little overzealous if it is set at the 1 second mark.